### PR TITLE
feat: allow multiple servers to launch in parallel

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,7 +38,7 @@ jobs:
       if: runner.os == 'Windows'
     - run: npm install --global webext-agent-*.tgz
       if: runner.os != 'Windows'
-    - run: webext-agent install
+    - run: webext-agent install --addon-ids "deadbeef@example.com"
     - run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- pnpm run test
       if: runner.os == 'Linux'
     - run: pnpm run test

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,7 +38,7 @@ jobs:
       if: runner.os == 'Windows'
     - run: npm install --global webext-agent-*.tgz
       if: runner.os != 'Windows'
-    - run: webext-agent install --addon-ids "deadbeef@example.com"
+    - run: webext-agent install --addon-ids "deadbeef@example.com,bareaddon@example.com"
     - run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- pnpm run test
       if: runner.os == 'Linux'
     - run: pnpm run test

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Create a new agent add-on:
 
 ```console
 $ webext-agent create-addon \
-    --additional-permissions tabs
+    --additional-permissions tabs \
     --addon-id my-addon@example.com
     /tmp/my-agent-addon
 ```
@@ -85,10 +85,10 @@ $ webext-agent install
 Create a new agent add-on.
 
 ```console
-$ webext-agent create-addon
-    --additional-permissions <permission1>,<permission2>,...
-    --addon-id <addon-id>
-    [--base-addon <base-addon>]
+$ webext-agent create-addon \
+    --additional-permissions <permission1>,<permission2>,... \
+    --addon-id <addon-id> \
+    [--base-addon <base-addon>] \
     <destination>
 ```
 

--- a/README.md
+++ b/README.md
@@ -14,18 +14,28 @@ $ yarn add webext-agent            # yarn
 $ pnpx webext-agent install        # pnpm
 ```
 
-Then install the native messaging manifest to the local:
+## Preparation
+
+The webext-agent access the browser via [native messaging][].  It requires a
+native messaging manifest to be installed to the local.  The webext-agent does
+not install the manifest automatically due to the security reason.  You can
+install it manually by the following command:
 
 ```console
-$ ./node_modules/.bin/webext-agent install
+$ webext-agent install --addon-ids my-addon1@example.com,my-addon2@example.com,...
 ```
+
+[native messaging]: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Native_messaging
 
 ## Quick start
 
 Create a new agent add-on:
 
 ```console
-$ webext-agent create-addon --additional-permissions tabs /tmp/my-agent-addon
+$ webext-agent create-addon \
+    --additional-permissions tabs
+    --addon-id my-addon@example.com
+    /tmp/my-agent-addon
 ```
 
 and load it via `about:config` on your Firefox browser.
@@ -35,7 +45,7 @@ The agent server starts and you can access APIs by the following JavaScript/Type
 const { connect } = require("webext-agent");
 
 (async () => {
-  const browser = await connect("127.0.0.1:12345");
+  const browser = await connect("my-addon@example.com");
   const tabs = await browser.tabs.query({});
 
   tabs.forEach((tab) => {
@@ -51,8 +61,7 @@ const { connect } = require("webext-agent");
 Install a native messaging manifest to the local
 
 ```console
-$ webext-agent install
-Installed native message manifest at /home/alice/.mozilla/native-messaging-hosts/demo.ueokande.webext_agent.json
+$ webext-agent install --addon-ids my-addon1@example.com,my-addon2@example.com,...
 ```
 
 ### uninstall
@@ -61,7 +70,6 @@ Uninstall the installed native messaging manifest from the local.
 
 ```console
 $ webext-agent uninstall
-Uninstalled native message manifest from /home/alice/.mozilla/native-messaging-hosts/demo.ueokande.webext_agent.json
 ```
 
 ### check
@@ -70,7 +78,6 @@ Check if the native message manifest is installed.
 
 ```console
 $ webext-agent install
-Installed native message manifest at /home/alice/.mozilla/native-messaging-hosts/demo.ueokande.webext_agent.json
 ```
 
 ### create-addon
@@ -78,15 +85,15 @@ Installed native message manifest at /home/alice/.mozilla/native-messaging-hosts
 Create a new agent add-on.
 
 ```console
-$ webext-agent create-addon --additional-permissions tabs /tmp/my-agent-addon
+$ webext-agent create-addon
+    --additional-permissions <permission1>,<permission2>,...
+    --addon-id <addon-id>
+    [--base-addon <base-addon>]
+    <destination>
 ```
 
 You can mix-in an agent add-on with your add-ons by `--base-addon` option.
 This is useful to debug or access the internal storage on your add-on.
-
-```console
-$ webext-agent create-addon --base-addon ~/workspace/my-addon /tmp/my-agent-addon
-```
 
 ## JavaScript/TypeScript API
 
@@ -112,6 +119,7 @@ console.log(addon.getRoot());
 - `destination` Destination directory to create an agent add-on.
 - `options`
     - `additionalPermissions` Additional permissions to be added to the add-on.
+    - `addonId` An id of the Addon
 
 ```typescript
 import { createMixedInAgentAddon } from "webext-agent";

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "pino": "^8.17.2",
     "regedit": "5.1.2",
     "tslib": "^2.6.2",
-    "uuid": "^8.3.2"
+    "uuid": "^8.3.2",
+    "zod": "^3.22.4"
   },
   "bin": {
     "webext-agent": "./bin/webext-agent.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ dependencies:
   uuid:
     specifier: ^8.3.2
     version: 8.3.2
+  zod:
+    specifier: ^3.22.4
+    version: 3.22.4
 
 devDependencies:
   '@playwright/test':
@@ -3841,3 +3844,7 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
     dev: true
+
+  /zod@3.22.4:
+    resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
+    dev: false

--- a/src/addon-builder/addon.ts
+++ b/src/addon-builder/addon.ts
@@ -24,12 +24,17 @@ class TemporaryAddon implements Addon {
 
 type AddonOptions = {
   additionalPermissions?: string[];
+  addonId?: string;
 };
 
 const createAgentAddon = async (
   destDir: string,
-  { additionalPermissions = [] }: AddonOptions = {},
+  { additionalPermissions = [], addonId }: AddonOptions = {},
 ): Promise<Addon> => {
+  if (typeof addonId === "undefined") {
+    throw new Error("addonId is required");
+  }
+
   if (fs.existsSync(destDir)) {
     await fs.promises.rm(destDir, { recursive: true });
   }
@@ -39,6 +44,7 @@ const createAgentAddon = async (
   const manifest = buildManifest({
     agentBackgroundScriptName,
     additionalPermissions,
+    addonId,
   });
   await fs.promises.copyFile(
     getTemplatePath(),
@@ -54,7 +60,7 @@ const createAgentAddon = async (
 const createMixedInAgentAddon = async (
   baseAddonDir: string,
   destDir: string,
-  { additionalPermissions }: AddonOptions = {},
+  { additionalPermissions, addonId }: AddonOptions = {},
 ): Promise<Addon> => {
   if (fs.existsSync(destDir)) {
     await fs.promises.rm(destDir, { recursive: true });
@@ -72,6 +78,7 @@ const createMixedInAgentAddon = async (
   const manifest = buildMixedInManifest(baseManifest, {
     agentBackgroundScriptName,
     additionalPermissions,
+    addonIdOverride: addonId,
   });
   await fs.promises.cp(baseAddonDir, destDir, { recursive: true });
   await fs.promises.copyFile(

--- a/src/addon-builder/manifest.ts
+++ b/src/addon-builder/manifest.ts
@@ -6,36 +6,48 @@ const DEFAULT_MANIFEST = {
   name: "webext-agent",
   description: "An agent to invoke WebExtensions APIs via remote",
   version: "0.0.1",
-  browser_specific_settings: {
-    gecko: {
-      id: "{daf44bf7-a45e-4450-979c-91cf07434c3d}",
-    },
-  },
   permissions: ["nativeMessaging"],
 };
 
-type manifestOptions = {
+type BuildManifestOption = {
   additionalPermissions?: Permissions;
   agentBackgroundScriptName: string;
+  addonId: string;
 };
 
 const buildManifest = ({
   additionalPermissions = [],
   agentBackgroundScriptName,
-}: manifestOptions): WebExtensionManifest => {
+  addonId,
+}: BuildManifestOption): WebExtensionManifest => {
   const manifest: WebExtensionManifest = {
     ...DEFAULT_MANIFEST,
     permissions: DEFAULT_MANIFEST.permissions.concat(additionalPermissions),
     background: {
       scripts: [agentBackgroundScriptName],
     },
+    browser_specific_settings: {
+      gecko: {
+        id: addonId,
+      },
+    },
   };
   return manifest;
 };
 
+type BuildMixedInManifestOption = {
+  additionalPermissions?: Permissions;
+  agentBackgroundScriptName: string;
+  addonIdOverride?: string;
+};
+
 const buildMixedInManifest = (
   baseManifest: WebExtensionManifest,
-  { additionalPermissions = [], agentBackgroundScriptName }: manifestOptions,
+  {
+    additionalPermissions = [],
+    agentBackgroundScriptName,
+    addonIdOverride,
+  }: BuildMixedInManifestOption,
 ): WebExtensionManifest => {
   const permissions = (baseManifest.permissions ?? [])
     .concat(DEFAULT_MANIFEST.permissions)
@@ -49,10 +61,13 @@ const buildMixedInManifest = (
   };
   const browser_specific_settings = {
     ...baseManifest.browser_specific_settings,
-    gecko: {
-      id: DEFAULT_MANIFEST.browser_specific_settings.gecko.id,
-    },
   };
+  if (addonIdOverride) {
+    if (!browser_specific_settings.gecko) {
+      browser_specific_settings.gecko = {};
+    }
+    browser_specific_settings.gecko.id = addonIdOverride;
+  }
   const manifest: WebExtensionManifest = {
     ...baseManifest,
     browser_specific_settings,
@@ -62,6 +77,4 @@ const buildMixedInManifest = (
   return manifest;
 };
 
-const addonGeckoId = () => DEFAULT_MANIFEST.browser_specific_settings.gecko.id;
-
-export { buildManifest, buildMixedInManifest, addonGeckoId };
+export { buildManifest, buildMixedInManifest };

--- a/src/agent-server/app.ts
+++ b/src/agent-server/app.ts
@@ -1,29 +1,81 @@
 import type { Readable, Writable } from "node:stream";
 import { start as startServer } from "./server";
 import { RPCClientImpl } from "./rpc";
-import { type Logger } from "pino";
+import pino, { type Logger } from "pino";
+import { LogDiscovery } from "../discovery/logs";
+import { EndpointDiscovery } from "../discovery/endpoints";
 
 type Options = {
-  port: number;
+  addonId: string;
+  port?: number;
+  dataDir: string;
   stdin: Readable;
   stdout: Writable;
-  logger: Logger;
+};
+
+const scheduleGracefulShutdown = (
+  server: { close: () => Promise<void> },
+  logger: Logger,
+) => {
+  process.on("SIGINT", async () => {
+    setTimeout(() => {
+      logger.error("Could not close server gracefully");
+      process.exit(1);
+    }, 3000);
+    await server.close();
+    process.exit();
+  });
 };
 
 export class Application {
   private readonly opts: Options;
   private readonly rpc: RPCClientImpl;
+  private readonly logDiscovery: LogDiscovery;
+  private readonly endpointDiscovery: EndpointDiscovery;
 
   constructor(opts: Options) {
+    this.logDiscovery = new LogDiscovery(opts.dataDir);
+    this.endpointDiscovery = new EndpointDiscovery(opts.dataDir);
     this.opts = opts;
     this.rpc = new RPCClientImpl(opts.stdin, opts.stdout);
   }
 
-  run() {
+  async run() {
+    const logFile = await this.logDiscovery.touchLog(this.opts.addonId);
+    const logger = pino(
+      { timestamp: pino.stdTimeFunctions.isoTime },
+      pino.destination(logFile),
+    );
     this.rpc.start();
     this.rpc.on("error", (err: Error) => {
-      this.opts.logger.error(err);
+      logger.error(err);
     });
-    startServer(this.opts.port, this.rpc, this.opts.logger);
+    const server = await startServer(this.opts.port, this.rpc, logger);
+    server.addHook("onListen", async () => {
+      const addresses = server
+        .addresses()
+        .filter((addr) => addr.family === "IPv4");
+      if (addresses.length === 0) {
+        throw new Error("Server did not listen with IPv4");
+      }
+      await this.endpointDiscovery.installAddon(
+        this.opts.addonId,
+        addresses[0],
+      );
+    });
+    server.addHook("onClose", async () => {
+      await this.endpointDiscovery.uninstallAddon(this.opts.addonId);
+    });
+
+    scheduleGracefulShutdown(server, logger);
+
+    process.stderr.write(
+      `This application is a agent server for webext-agent and does not expect run manually
+You can see server logs at the following path:
+
+  ${logFile}
+
+`,
+    );
   }
 }

--- a/src/agent-server/app.ts
+++ b/src/agent-server/app.ts
@@ -17,13 +17,15 @@ const scheduleGracefulShutdown = (
   server: { close: () => Promise<void> },
   logger: Logger,
 ) => {
-  process.on("SIGINT", async () => {
-    setTimeout(() => {
-      logger.error("Could not close server gracefully");
-      process.exit(1);
-    }, 3000);
-    await server.close();
-    process.exit();
+  ["SIGINT", "SIGTERM"].forEach((signal) => {
+    process.on(signal, async () => {
+      setTimeout(() => {
+        logger.error("Could not close server gracefully");
+        process.exit(1);
+      }, 3000);
+      await server.close();
+      process.exit();
+    });
   });
 };
 

--- a/src/agent-server/server.ts
+++ b/src/agent-server/server.ts
@@ -4,15 +4,29 @@ import { newRoute as newApiRoute } from "./routeApi";
 import { newRoute as newHealthRoute } from "./routeHealth";
 import { type RPCClient } from "./rpc";
 
-const start = (port: number, rcp: RPCClient, logger: Logger) => {
+const start = async (
+  port: number | undefined,
+  rcp: RPCClient,
+  logger: Logger,
+) => {
   const fastify = Fastify({ logger });
   fastify.register(
-    newApiRoute((method: string, args: unknown[]) => {
-      return rcp.request({ method, args });
+    newApiRoute(async (method: string, args: unknown[]) => {
+      logger.warn({ method, args }, "request");
+      try {
+        const resp = await rcp.request({ method, args });
+        logger.warn({ resp: resp }, "response");
+        return resp;
+      } catch (e) {
+        logger.error({ error: e, errstring: String(e) }, "error");
+        throw e;
+      }
     }),
   );
   fastify.register(newHealthRoute());
   fastify.listen({ port });
+
+  return fastify;
 };
 
 export { start };

--- a/src/cli/agent-server/index.ts
+++ b/src/cli/agent-server/index.ts
@@ -2,42 +2,27 @@ import * as os from "node:os";
 import path from "node:path";
 import { program } from "commander";
 import { Application } from "../../agent-server";
-import pino from "pino";
 
-const defaultPort = 12345;
-const logPath = path.join(os.tmpdir(), "webext-agent.log");
+const DEFAULT_DATA_DIR = path.join(os.tmpdir(), "webext-agent");
 
-program.option(
-  "-p, --port <number>",
-  `Port number to be listen on (defualt: ${defaultPort})`,
-);
-program.parse();
+program
+  .argument("<manifest>", "Path to native messaging manifest")
+  .argument("<addon_id>", "Addon ID")
+  .option("-p, --port <number>", `Port number to be listen on`)
+  .option("-d, --data-dir <path>", `Path to data directory`, DEFAULT_DATA_DIR)
+  .parse();
 
 const opts = program.opts();
-const port = Number(opts.port ?? defaultPort);
 
-if (isNaN(port)) {
+if (typeof opts.port !== "undefined" && isNaN(Number(opts.port))) {
   console.error("invalid option --port");
   process.exit(2);
 }
 
-process.stderr.write(
-  `This application is a agent server for webext-agent and does not expect run manually
-You can see server logs at the following path:
-
-  ${logPath}
-
-`,
-);
-
 const app = new Application({
-  port,
-  logger: pino(
-    {
-      timestamp: pino.stdTimeFunctions.isoTime,
-    },
-    pino.destination(logPath),
-  ),
+  addonId: program.args[1],
+  port: opts.port,
+  dataDir: opts.dataDir,
   stdin: process.stdin,
   stdout: process.stdout,
 });

--- a/src/discovery/endpoints.ts
+++ b/src/discovery/endpoints.ts
@@ -1,0 +1,87 @@
+import path from "node:path";
+import fs from "node:fs/promises";
+import os from "node:os";
+import { z } from "zod";
+import { AddonLocation } from "./types";
+
+const DEFAULT_DATA_DIR = path.join(os.tmpdir(), "webext-agent");
+const DEFAULT_STORAGE_PATH = path.join(DEFAULT_DATA_DIR, "endpoints.state");
+
+const EndpointStorageSchemaV1 = z.object({
+  version: z.literal(1),
+  endpoints: z.array(
+    z.object({
+      profilePath: z.string(),
+      addonId: z.string(),
+      address: z.string(),
+      port: z.number(),
+    }),
+  ),
+});
+
+type EndpointStorageSchemaV1 = z.infer<typeof EndpointStorageSchemaV1>;
+
+type Endpoint = {
+  address: string;
+  port: number;
+};
+
+export class EndpointDiscovery {
+  constructor(private readonly storagePath: string = DEFAULT_STORAGE_PATH) {}
+
+  async installAddon(
+    { profilePath, addonId }: AddonLocation,
+    { address, port }: Endpoint,
+  ): Promise<void> {
+    const state = await this.loadOrCreate();
+    state.endpoints.push({ profilePath, addonId, address, port });
+    await this.save(state);
+  }
+
+  async uninstallAddon({ profilePath, addonId }: AddonLocation): Promise<void> {
+    const state = await this.loadOrCreate();
+    state.endpoints = state.endpoints.filter(
+      (entry) => entry.profilePath !== profilePath || entry.addonId !== addonId,
+    );
+    await this.save(state);
+  }
+
+  async resolveEndpoint({
+    profilePath,
+    addonId,
+  }: AddonLocation): Promise<Endpoint | null> {
+    const state = await this.loadOrCreate();
+    const entry = state.endpoints.find(
+      (entry) => entry.profilePath === profilePath && entry.addonId === addonId,
+    );
+    if (entry) {
+      return { address: entry.address, port: entry.port };
+    }
+    return null;
+  }
+
+  private async save(state: EndpointStorageSchemaV1) {
+    const tmpfile = `${this.storagePath}.${process.pid}`;
+    await fs.mkdir(path.dirname(this.storagePath), { recursive: true });
+    await fs.writeFile(tmpfile, JSON.stringify(state));
+    await fs.rename(tmpfile, this.storagePath);
+  }
+
+  private async loadOrCreate(): Promise<EndpointStorageSchemaV1> {
+    const content = await (async () => {
+      try {
+        return await fs.readFile(this.storagePath, "utf-8");
+      } catch (e: any) {
+        if (e.code === "ENOENT") {
+          return null;
+        }
+        throw e;
+      }
+    })();
+    if (content === null) {
+      return { version: 1, endpoints: [] };
+    }
+
+    return EndpointStorageSchemaV1.parse(JSON.parse(content));
+  }
+}

--- a/src/discovery/endpoints.ts
+++ b/src/discovery/endpoints.ts
@@ -34,6 +34,9 @@ export class EndpointDiscovery {
     { address, port }: Endpoint,
   ): Promise<void> {
     const state = await this.loadOrCreate();
+    state.endpoints = state.endpoints.filter(
+      (entry) => entry.addonId !== addonId,
+    );
     state.endpoints.push({ addonId, address, port });
     await this.save(state);
   }

--- a/src/discovery/endpoints.ts
+++ b/src/discovery/endpoints.ts
@@ -1,10 +1,8 @@
 import path from "node:path";
 import fs from "node:fs/promises";
-import os from "node:os";
 import { z } from "zod";
 
-const DEFAULT_DATA_DIR = path.join(os.tmpdir(), "webext-agent");
-const DEFAULT_STORAGE_PATH = path.join(DEFAULT_DATA_DIR, "endpoints.state");
+const ENDPOINTS_JSON_FILE = "endpoints.json";
 
 const EndpointStorageSchemaV1 = z.object({
   version: z.literal(1),
@@ -25,7 +23,11 @@ type Endpoint = {
 };
 
 export class EndpointDiscovery {
-  constructor(private readonly storagePath: string = DEFAULT_STORAGE_PATH) {}
+  private readonly storagePath;
+
+  constructor(dataDir: string) {
+    this.storagePath = path.join(dataDir, ENDPOINTS_JSON_FILE);
+  }
 
   async installAddon(
     addonId: string,

--- a/src/discovery/logs.ts
+++ b/src/discovery/logs.ts
@@ -1,0 +1,83 @@
+import path from "node:path";
+import os from "node:os";
+import fs from "node:fs/promises";
+import { v4 as uuidv4 } from "uuid";
+import { z } from "zod";
+import { AddonLocation } from "./types";
+
+const DEFAULT_LOG_DIR = path.join(os.tmpdir(), "webext-agent", "logs");
+const STATE_FILENAME = "state.json";
+
+const LogStateSchemaV1 = z.object({
+  version: z.literal(1),
+  entries: z.array(
+    z.object({
+      profilePath: z.string(),
+      addonId: z.string(),
+      logPath: z.string(),
+    }),
+  ),
+});
+
+type LogStateSchemaV1 = z.infer<typeof LogStateSchemaV1>;
+
+export class LogDiscovery {
+  constructor(private readonly logDir: string = DEFAULT_LOG_DIR) {}
+
+  async resolvePath({
+    profilePath,
+    addonId,
+  }: AddonLocation): Promise<string | null> {
+    const state = await this.loadOrCreateState();
+    const entry = state.entries.find(
+      (entry) => entry.profilePath === profilePath && entry.addonId === addonId,
+    );
+    if (entry) {
+      return entry.logPath;
+    }
+    return null;
+  }
+
+  async touchLog({ profilePath, addonId }: AddonLocation): Promise<string> {
+    const state = await this.loadOrCreateState();
+    const entry = state.entries.find(
+      (entry) => entry.profilePath === profilePath && entry.addonId === addonId,
+    );
+    if (entry) {
+      return entry.logPath;
+    }
+
+    const logPath = path.join(this.logDir, `${uuidv4()}.log`);
+    state.entries.push({ profilePath, addonId, logPath });
+    await this.saveState(state);
+    await fs.appendFile(logPath, Buffer.from([]));
+    return logPath;
+  }
+
+  private async loadOrCreateState(): Promise<LogStateSchemaV1> {
+    const content = await (async () => {
+      try {
+        return await fs.readFile(
+          path.join(this.logDir, STATE_FILENAME),
+          "utf-8",
+        );
+      } catch (e: any) {
+        if (e.code === "ENOENT") {
+          return null;
+        }
+        throw e;
+      }
+    })();
+    if (content === null) {
+      return { version: 1, entries: [] };
+    }
+    return LogStateSchemaV1.parse(JSON.parse(content));
+  }
+
+  private async saveState(state: LogStateSchemaV1): Promise<void> {
+    const tmpfile = path.join(this.logDir, `${STATE_FILENAME}.tmp`);
+    await fs.mkdir(this.logDir, { recursive: true });
+    await fs.writeFile(tmpfile, JSON.stringify(state));
+    await fs.rename(tmpfile, path.join(this.logDir, STATE_FILENAME));
+  }
+}

--- a/src/discovery/types.ts
+++ b/src/discovery/types.ts
@@ -1,0 +1,4 @@
+export type AddonLocation = {
+  profilePath: string;
+  addonId: string;
+};

--- a/src/discovery/types.ts
+++ b/src/discovery/types.ts
@@ -1,4 +1,0 @@
-export type AddonLocation = {
-  profilePath: string;
-  addonId: string;
-};

--- a/tests/addon-builder/manifest.test.ts
+++ b/tests/addon-builder/manifest.test.ts
@@ -8,19 +8,26 @@ describe("buildManifest", () => {
   const agentBackgroundScriptName = `${uuidv4()}.js`;
 
   test("should generate an addon manifest", () => {
-    const manifest = buildManifest({ agentBackgroundScriptName });
+    const manifest = buildManifest({
+      agentBackgroundScriptName,
+      addonId: "myaddon@example.com",
+    });
     expect(manifest.manifest_version).toBe(3);
     expect(manifest.name).toBe("webext-agent");
     expect(manifest.background).toEqual({
       scripts: [agentBackgroundScriptName],
     });
     expect(manifest.permissions).toEqual(["nativeMessaging"]);
+    expect(manifest.browser_specific_settings?.gecko?.id).toBe(
+      "myaddon@example.com",
+    );
   });
 
   test("should override permissions", () => {
     const manifest = buildManifest({
       agentBackgroundScriptName,
       additionalPermissions: ["bookmarks"],
+      addonId: "myaddon@example.com",
     });
     expect(manifest.manifest_version).toBe(3);
     expect(manifest.name).toBe("webext-agent");
@@ -28,28 +35,30 @@ describe("buildManifest", () => {
       scripts: [agentBackgroundScriptName],
     });
     expect(manifest.permissions).toEqual(["nativeMessaging", "bookmarks"]);
+    expect(manifest.browser_specific_settings?.gecko?.id).toBe(
+      "myaddon@example.com",
+    );
   });
 });
 
 describe("buildMixedInManifest", () => {
   const agentBackgroundScriptName = `${uuidv4()}.js`;
-
-  test("should override manifest properties", () => {
-    const baseManifest = {
-      manifest_version: 3,
-      name: "my-addon",
-      version: "1.0.0",
-      applications: {
-        gecko: {
-          id: "myaddon@exapmle.com",
-        },
+  const baseManifest = {
+    manifest_version: 3,
+    name: "my-addon",
+    version: "1.0.0",
+    browser_specific_settings: {
+      gecko: {
+        id: "myaddon@example.com",
       },
-      background: {
-        scripts: ["my-script.js"],
-      },
-      permissions: ["bookmarks"],
-    };
+    },
+    background: {
+      scripts: ["my-script.js"],
+    },
+    permissions: ["bookmarks"],
+  };
 
+  test("should generate an addon manifest", () => {
     const manifest = buildMixedInManifest(baseManifest, {
       agentBackgroundScriptName,
     });
@@ -58,5 +67,23 @@ describe("buildMixedInManifest", () => {
       scripts: ["my-script.js", agentBackgroundScriptName],
     });
     expect(manifest.permissions).toEqual(["bookmarks", "nativeMessaging"]);
+    expect(manifest.browser_specific_settings?.gecko?.id).toBe(
+      "myaddon@example.com",
+    );
+  });
+
+  test("should override manifest properties", () => {
+    const manifest = buildMixedInManifest(baseManifest, {
+      agentBackgroundScriptName,
+      addonIdOverride: "newname@example.com",
+    });
+    expect(manifest.manifest_version).toBe(3);
+    expect(manifest.background).toEqual({
+      scripts: ["my-script.js", agentBackgroundScriptName],
+    });
+    expect(manifest.permissions).toEqual(["bookmarks", "nativeMessaging"]);
+    expect(manifest.browser_specific_settings?.gecko?.id).toBe(
+      "newname@example.com",
+    );
   });
 });

--- a/tests/discovery/endpoints.test.ts
+++ b/tests/discovery/endpoints.test.ts
@@ -15,12 +15,12 @@ describe("EndpointDiscovery", () => {
   });
 
   test("discover endpoints", async () => {
-    const p1 = new EndpointDiscovery(path.join(tmpdir, "endpoints.json"));
+    const p1 = new EndpointDiscovery(tmpdir);
 
     await p1.installAddon("addon1", { address: "127.0.0.1", port: 10000 });
     await p1.installAddon("addon2", { address: "127.0.0.1", port: 10001 });
 
-    const p2 = new EndpointDiscovery(path.join(tmpdir, "endpoints.json"));
+    const p2 = new EndpointDiscovery(tmpdir);
     await expect(p2.resolveEndpoint("addon1")).resolves.toEqual({
       address: "127.0.0.1",
       port: 10000,
@@ -30,5 +30,18 @@ describe("EndpointDiscovery", () => {
       port: 10001,
     });
     await expect(p2.resolveEndpoint("addon3")).resolves.toBeNull();
+  });
+
+  test("overwrite endpoints", async () => {
+    const p1 = new EndpointDiscovery(tmpdir);
+
+    await p1.installAddon("addon1", { address: "127.0.0.1", port: 10000 });
+    await p1.installAddon("addon1", { address: "127.0.0.1", port: 10001 });
+
+    const p2 = new EndpointDiscovery(tmpdir);
+    await expect(p2.resolveEndpoint("addon1")).resolves.toEqual({
+      address: "127.0.0.1",
+      port: 10001,
+    });
   });
 });

--- a/tests/discovery/endpoints.test.ts
+++ b/tests/discovery/endpoints.test.ts
@@ -17,31 +17,18 @@ describe("EndpointDiscovery", () => {
   test("discover endpoints", async () => {
     const p1 = new EndpointDiscovery(path.join(tmpdir, "endpoints.json"));
 
-    await p1.installAddon(
-      { profilePath: "/tmp/profile1", addonId: "addon1" },
-      { address: "127.0.0.1", port: 10000 },
-    );
-    await p1.installAddon(
-      { profilePath: "/tmp/profile1", addonId: "addon2" },
-      { address: "127.0.0.1", port: 10001 },
-    );
-    await p1.installAddon(
-      { profilePath: "/tmp/profile2", addonId: "addon1" },
-      { address: "127.0.0.1", port: 10002 },
-    );
+    await p1.installAddon("addon1", { address: "127.0.0.1", port: 10000 });
+    await p1.installAddon("addon2", { address: "127.0.0.1", port: 10001 });
 
     const p2 = new EndpointDiscovery(path.join(tmpdir, "endpoints.json"));
-    await expect(
-      p2.resolveEndpoint({ profilePath: "/tmp/profile1", addonId: "addon1" }),
-    ).resolves.toEqual({ address: "127.0.0.1", port: 10000 });
-    await expect(
-      p2.resolveEndpoint({ profilePath: "/tmp/profile1", addonId: "addon2" }),
-    ).resolves.toEqual({ address: "127.0.0.1", port: 10001 });
-    await expect(
-      p2.resolveEndpoint({ profilePath: "/tmp/profile2", addonId: "addon1" }),
-    ).resolves.toEqual({ address: "127.0.0.1", port: 10002 });
-    await expect(
-      p2.resolveEndpoint({ profilePath: "/tmp/profile2", addonId: "addon2" }),
-    ).resolves.toBeNull();
+    await expect(p2.resolveEndpoint("addon1")).resolves.toEqual({
+      address: "127.0.0.1",
+      port: 10000,
+    });
+    await expect(p2.resolveEndpoint("addon2")).resolves.toEqual({
+      address: "127.0.0.1",
+      port: 10001,
+    });
+    await expect(p2.resolveEndpoint("addon3")).resolves.toBeNull();
   });
 });

--- a/tests/discovery/endpoints.test.ts
+++ b/tests/discovery/endpoints.test.ts
@@ -1,0 +1,47 @@
+import path from "node:path";
+import os from "node:os";
+import fs from "node:fs/promises";
+import { EndpointDiscovery } from "../../src/discovery/endpoints";
+
+describe("EndpointDiscovery", () => {
+  let tmpdir: string;
+
+  beforeEach(async () => {
+    tmpdir = await fs.mkdtemp(path.join(os.tmpdir(), "webext-agent-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpdir, { recursive: true });
+  });
+
+  test("discover endpoints", async () => {
+    const p1 = new EndpointDiscovery(path.join(tmpdir, "endpoints.json"));
+
+    await p1.installAddon(
+      { profilePath: "/tmp/profile1", addonId: "addon1" },
+      { address: "127.0.0.1", port: 10000 },
+    );
+    await p1.installAddon(
+      { profilePath: "/tmp/profile1", addonId: "addon2" },
+      { address: "127.0.0.1", port: 10001 },
+    );
+    await p1.installAddon(
+      { profilePath: "/tmp/profile2", addonId: "addon1" },
+      { address: "127.0.0.1", port: 10002 },
+    );
+
+    const p2 = new EndpointDiscovery(path.join(tmpdir, "endpoints.json"));
+    await expect(
+      p2.resolveEndpoint({ profilePath: "/tmp/profile1", addonId: "addon1" }),
+    ).resolves.toEqual({ address: "127.0.0.1", port: 10000 });
+    await expect(
+      p2.resolveEndpoint({ profilePath: "/tmp/profile1", addonId: "addon2" }),
+    ).resolves.toEqual({ address: "127.0.0.1", port: 10001 });
+    await expect(
+      p2.resolveEndpoint({ profilePath: "/tmp/profile2", addonId: "addon1" }),
+    ).resolves.toEqual({ address: "127.0.0.1", port: 10002 });
+    await expect(
+      p2.resolveEndpoint({ profilePath: "/tmp/profile2", addonId: "addon2" }),
+    ).resolves.toBeNull();
+  });
+});

--- a/tests/discovery/logs.test.ts
+++ b/tests/discovery/logs.test.ts
@@ -1,0 +1,70 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { LogDiscovery } from "../../src/discovery/logs";
+
+describe("LogDiscovery", () => {
+  let tmpdir: string;
+
+  beforeEach(async () => {
+    tmpdir = await fs.mkdtemp(path.join(os.tmpdir(), "webext-agent-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpdir, { recursive: true });
+  });
+
+  test("discover endpoints", async () => {
+    const p1 = new LogDiscovery(tmpdir);
+    const f1 = await p1.touchLog({
+      profilePath: "/tmp/profile1",
+      addonId: "addon1",
+    });
+    const f2 = await p1.touchLog({
+      profilePath: "/tmp/profile1",
+      addonId: "addon2",
+    });
+    const f3 = await p1.touchLog({
+      profilePath: "/tmp/profile2",
+      addonId: "addon1",
+    });
+
+    const p2 = new LogDiscovery(tmpdir);
+    await expect(
+      p2.resolvePath({ profilePath: "/tmp/profile1", addonId: "addon1" }),
+    ).resolves.toEqual(f1);
+    await expect(
+      p2.resolvePath({ profilePath: "/tmp/profile1", addonId: "addon2" }),
+    ).resolves.toEqual(f2);
+    await expect(
+      p2.resolvePath({ profilePath: "/tmp/profile2", addonId: "addon1" }),
+    ).resolves.toEqual(f3);
+    await expect(
+      p2.resolvePath({ profilePath: "/tmp/profile2", addonId: "addon2" }),
+    ).resolves.toBeNull();
+
+    await expect(fs.readFile(f1, { encoding: "utf-8" })).resolves.toBe("");
+    await expect(fs.readFile(f2, { encoding: "utf-8" })).resolves.toBe("");
+    await expect(fs.readFile(f3, { encoding: "utf-8" })).resolves.toBe("");
+  });
+
+  test("do not overwrite existing logs", async () => {
+    const p1 = new LogDiscovery(tmpdir);
+    const f1 = await p1.touchLog({
+      profilePath: "/tmp/profile1",
+      addonId: "addon1",
+    });
+    await fs.writeFile(f1, `{ "msg": "hello" }`);
+
+    const p2 = new LogDiscovery(tmpdir);
+    const f2 = await p2.touchLog({
+      profilePath: "/tmp/profile1",
+      addonId: "addon1",
+    });
+
+    expect(f1).toEqual(f2);
+    await expect(fs.readFile(f1, { encoding: "utf-8" })).resolves.toBe(
+      `{ "msg": "hello" }`,
+    );
+  });
+});

--- a/tests/discovery/logs.test.ts
+++ b/tests/discovery/logs.test.ts
@@ -16,51 +16,24 @@ describe("LogDiscovery", () => {
 
   test("discover endpoints", async () => {
     const p1 = new LogDiscovery(tmpdir);
-    const f1 = await p1.touchLog({
-      profilePath: "/tmp/profile1",
-      addonId: "addon1",
-    });
-    const f2 = await p1.touchLog({
-      profilePath: "/tmp/profile1",
-      addonId: "addon2",
-    });
-    const f3 = await p1.touchLog({
-      profilePath: "/tmp/profile2",
-      addonId: "addon1",
-    });
+    const f1 = await p1.touchLog("addon1");
+    const f2 = await p1.touchLog("addon2");
 
     const p2 = new LogDiscovery(tmpdir);
-    await expect(
-      p2.resolvePath({ profilePath: "/tmp/profile1", addonId: "addon1" }),
-    ).resolves.toEqual(f1);
-    await expect(
-      p2.resolvePath({ profilePath: "/tmp/profile1", addonId: "addon2" }),
-    ).resolves.toEqual(f2);
-    await expect(
-      p2.resolvePath({ profilePath: "/tmp/profile2", addonId: "addon1" }),
-    ).resolves.toEqual(f3);
-    await expect(
-      p2.resolvePath({ profilePath: "/tmp/profile2", addonId: "addon2" }),
-    ).resolves.toBeNull();
+    await expect(p2.resolvePath("addon1")).resolves.toEqual(f1);
+    await expect(p2.resolvePath("addon2")).resolves.toEqual(f2);
 
     await expect(fs.readFile(f1, { encoding: "utf-8" })).resolves.toBe("");
     await expect(fs.readFile(f2, { encoding: "utf-8" })).resolves.toBe("");
-    await expect(fs.readFile(f3, { encoding: "utf-8" })).resolves.toBe("");
   });
 
   test("do not overwrite existing logs", async () => {
     const p1 = new LogDiscovery(tmpdir);
-    const f1 = await p1.touchLog({
-      profilePath: "/tmp/profile1",
-      addonId: "addon1",
-    });
+    const f1 = await p1.touchLog("addon1");
     await fs.writeFile(f1, `{ "msg": "hello" }`);
 
     const p2 = new LogDiscovery(tmpdir);
-    const f2 = await p2.touchLog({
-      profilePath: "/tmp/profile1",
-      addonId: "addon1",
-    });
+    const f2 = await p2.touchLog("addon1");
 
     expect(f1).toEqual(f2);
     await expect(fs.readFile(f1, { encoding: "utf-8" })).resolves.toBe(

--- a/tests/integration/integration.test.ts
+++ b/tests/integration/integration.test.ts
@@ -16,6 +16,7 @@ describe("bare agent addon", () => {
 
     const addon = await createAgentAddon(root, {
       additionalPermissions: ["tabs"],
+      addonId: "bareaddon@example.com",
     });
 
     const browserTypeWithExtension = withExtension(firefox, addon.getRoot());
@@ -31,7 +32,7 @@ describe("bare agent addon", () => {
     const page = await browserContext.newPage();
     await page.goto("https://example.com/");
 
-    const browser = await connect("127.0.0.1:12345");
+    const browser = await connect("bareaddon@example.com");
     const tabs = await browser.tabs.query({});
 
     expect(tabs).toHaveLength(1);
@@ -65,7 +66,7 @@ describe("mixed-in agent addon", () => {
     const page = await browserContext.newPage();
     await page.goto("https://example.com/");
 
-    const browser = await connect("127.0.0.1:12345");
+    const browser = await connect("deadbeef@example.com");
     expect(await browser.storage.local.get("string")).toEqual({
       string: "dead beef",
     });

--- a/tests/integration/testdata/deadbeef-addon/manifest.json
+++ b/tests/integration/testdata/deadbeef-addon/manifest.json
@@ -6,5 +6,10 @@
   "background": {
     "scripts": ["background.js"]
   },
-  "permissions": ["storage"]
+  "permissions": ["storage"],
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "deadbeef@example.com"
+    }
+  }
 }

--- a/tests/webext-api/http.test.ts
+++ b/tests/webext-api/http.test.ts
@@ -1,40 +1,130 @@
+import path from "node:path";
+import os from "node:os";
+import fs from "node:fs/promises";
 import Fastify from "fastify";
-import { createRemoteAPIs } from "../../src/webext-api/http";
+import { EndpointDiscovery } from "../../src/discovery/endpoints";
+import { connect, createRemoteAPIs } from "../../src/webext-api/http";
 
-const fastify = Fastify();
-let capture: { url: string; body: unknown } | undefined = undefined;
+describe("createRemoteAPIs", () => {
+  const fastify = Fastify();
+  let capture: { url: string; body: unknown } | undefined = undefined;
 
-beforeEach(async () => {
-  fastify.post("/api/*", (req) => {
-    capture = { url: req.url, body: req.body };
-    return {};
-  });
-  await fastify.listen({ host: "127.0.0.1", port: 0 });
-  await fastify.ready();
-});
-
-afterEach(async () => {
-  await fastify.close();
-});
-
-test("should invoke WebExtensions APIs remotely", async () => {
-  const addr = fastify.server.address();
-  if (addr === null) {
-    throw new Error("addr is null");
-  }
-  const browser = createRemoteAPIs(addr);
-  await browser.bookmarks.create({
-    title: "my item",
-    url: "https://example.com/",
+  beforeEach(async () => {
+    fastify.post("/api/*", (req) => {
+      capture = { url: req.url, body: req.body };
+      return {};
+    });
+    await fastify.listen({ host: "127.0.0.1", port: 0 });
+    await fastify.ready();
   });
 
-  expect(capture?.url).toEqual("/api/bookmarks.create");
-  expect(capture?.body).toEqual({
-    args: [
-      {
-        title: "my item",
-        url: "https://example.com/",
-      },
-    ],
+  afterEach(async () => {
+    await fastify.close();
+  });
+
+  test("should invoke WebExtensions APIs remotely", async () => {
+    const addr = fastify.server.address();
+    if (addr === null) {
+      throw new Error("addr is null");
+    }
+    const browser = createRemoteAPIs(addr);
+    await browser.bookmarks.create({
+      title: "my item",
+      url: "https://example.com/",
+    });
+
+    expect(capture?.url).toEqual("/api/bookmarks.create");
+    expect(capture?.body).toEqual({
+      args: [
+        {
+          title: "my item",
+          url: "https://example.com/",
+        },
+      ],
+    });
+  });
+});
+
+describe("connect with an addon", () => {
+  const fastify = Fastify();
+  let healthCount = 0;
+  beforeEach(async () => {
+    fastify.get("/health", () => {
+      healthCount++;
+      if (healthCount < 5) {
+        throw new Error("not ready");
+      }
+      return {};
+    });
+    await fastify.listen({ host: "127.0.0.1", port: 0 });
+    await fastify.ready();
+  });
+
+  afterEach(async () => {
+    await fastify.close();
+  });
+
+  test("should invoke WebExtensions APIs remotely", async () => {
+    const addr = fastify.server.address();
+    if (addr === null) {
+      throw new Error("addr is null");
+    }
+
+    await connect(addr, { attempts: 5 });
+    expect(healthCount).toEqual(5);
+  });
+});
+
+describe.only("connect with an addon id", () => {
+  const fastify = Fastify();
+  let tmpdir: string;
+  let capture: { url: string; body: unknown } | undefined = undefined;
+
+  beforeEach(async () => {
+    tmpdir = await fs.mkdtemp(path.join(os.tmpdir(), "webext-agent-"));
+
+    fastify.get("/health", () => ({}));
+    fastify.post("/api/*", (req) => {
+      capture = { url: req.url, body: req.body };
+      return {};
+    });
+    await fastify.listen({ host: "127.0.0.1", port: 0 });
+    await fastify.ready();
+  });
+
+  afterEach(async () => {
+    await fastify.close();
+    await fs.rm(tmpdir, { recursive: true });
+  });
+
+  test("shuold discover an endpoint from the addon id", async () => {
+    const addr = fastify.server.address();
+    if (addr === null || typeof addr === "string") {
+      throw new Error("addr is not an AddressInfo");
+    }
+
+    const discovery = new EndpointDiscovery(tmpdir);
+    await discovery.installAddon("{9ca5a5f6-045f-4a35-a537-17cd899a189d}", {
+      address: addr.address,
+      port: addr.port,
+    });
+
+    const browser = await connect("{9ca5a5f6-045f-4a35-a537-17cd899a189d}", {
+      dataDir: tmpdir,
+    });
+    await browser.bookmarks.create({
+      title: "my item",
+      url: "https://example.com/",
+    });
+
+    expect(capture?.url).toEqual("/api/bookmarks.create");
+    expect(capture?.body).toEqual({
+      args: [
+        {
+          title: "my item",
+          url: "https://example.com/",
+        },
+      ],
+    });
   });
 });

--- a/tests/webext-api/http.test.ts
+++ b/tests/webext-api/http.test.ts
@@ -75,7 +75,7 @@ describe("connect with an addon", () => {
   });
 });
 
-describe.only("connect with an addon id", () => {
+describe("connect with an addon id", () => {
   const fastify = Fastify();
   let tmpdir: string;
   let capture: { url: string; body: unknown } | undefined = undefined;


### PR DESCRIPTION
This pull request support to launch multiple addon with the agent.
- Use a random port when server launches.
- Store port to the data directory.
- Allow to connect by an addon id.